### PR TITLE
Fix compilation error of 'bool' types with bindgen

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -455,6 +455,10 @@ impl Config {
     fn generate_bindgen_header(&mut self, lib: &str) {
         self.bindgen_header = self.get_out_dir().join(format!("_{}_ispc_bindgen_header.h", lib));
         let mut include_file = File::create(&self.bindgen_header).unwrap();
+       
+        write!(include_file, "#include <stdint.h>\n").unwrap();
+        write!(include_file, "#include <stdbool.h>\n").unwrap();
+
         for h in &self.headers[..] {
             write!(include_file, "#include \"{}\"\n", h.display()).unwrap();
         }


### PR DESCRIPTION
I ran into some issues using ispc-rs for more complex kernels (i.e. Intel's ispc-based texture compressor)

```
cargo:rustc-link-lib=static=kernel
cargo:rustc-link-search=native=H:\Repositories\ibis\Utilities\tex_comp\target\debug\build\tex_comp-87763e9d19faf5b9\out

--- stderr
H:\Repositories\ibis\Utilities\tex_comp\target\debug\build\tex_comp-87763e9d19faf5b9\out\kernel_ispc.h:43:5: error: unknown type name 'bool'
H:\Repositories\ibis\Utilities\tex_comp\target\debug\build\tex_comp-87763e9d19faf5b9\out\kernel_ispc.h:44:5: error: unknown type name 'bool'
H:\Repositories\ibis\Utilities\tex_comp\target\debug\build\tex_comp-87763e9d19faf5b9\out\kernel_ispc.h:54:5: error: unknown type name 'bool'
H:\Repositories\ibis\Utilities\tex_comp\target\debug\build\tex_comp-87763e9d19faf5b9\out\kernel_ispc.h:56:5: error: unknown type name 'bool'
H:\Repositories\ibis\Utilities\tex_comp\target\debug\build\tex_comp-87763e9d19faf5b9\out\kernel_ispc.h:43:5: error: unknown type name 'bool', err: true
H:\Repositories\ibis\Utilities\tex_comp\target\debug\build\tex_comp-87763e9d19faf5b9\out\kernel_ispc.h:44:5: error: unknown type name 'bool', err: true
H:\Repositories\ibis\Utilities\tex_comp\target\debug\build\tex_comp-87763e9d19faf5b9\out\kernel_ispc.h:54:5: error: unknown type name 'bool', err: true
H:\Repositories\ibis\Utilities\tex_comp\target\debug\build\tex_comp-87763e9d19faf5b9\out\kernel_ispc.h:56:5: error: unknown type name 'bool', err: true
```

Line 43 is the first occurrence of `bool` in the code below:
```
#ifndef __ISPC_STRUCT_bc6h_enc_settings__
#define __ISPC_STRUCT_bc6h_enc_settings__
struct bc6h_enc_settings {
    bool slow_mode;
    bool fast_mode;
    int32_t refineIterations_1p;
    int32_t refineIterations_2p;
    int32_t fastSkipTreshold;
};
#endif
```

The issue comes down to bool not being a built-in type, so we need to include both `stdint.h` and `stdbool.h` so that the code will compile with bindgen correctly.

For example, the perlin example now generates a global header that looks like this:
```
#include <stdint.h>
#include <stdbool.h>
#include "H:\Repositories\ispc-rs\examples\perlin\target\debug\build\perlin-b4de9389a15e899e\out\perlin_ispc.h"
```

After making this change, I am able to fully compile everything I've thrown at it ;)

Cheers!
Graham