### PR TITLE
Silence missing bindgen warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ispc"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Will Usher <willusher.life@gmail.com>"]
 homepage = "https://github.com/Twinklebear/ispc-rs"
 documentation = "http://www.willusher.io/ispc-rs/ispc/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -434,7 +434,7 @@ impl Config {
             Ok(f) => f,
             Err(e) => exit_failure!("Failed to open bindgen mod file for writing: {}", e),
         };
-        file.write_all("#[allow(non_camel_case_types,dead_code,non_upper_case_globals)]\n"
+        file.write_all("#[allow(non_camel_case_types,dead_code,non_upper_case_globals,non_snake_case,improper_ctypes)]\n"
                        .as_bytes()).unwrap();
         file.write_all(format!("pub mod {} {{\n", lib).as_bytes()).unwrap();
         file.write_all(generated_bindings.as_bytes()).unwrap();


### PR DESCRIPTION
I'm getting `non_snake_case` warnings from the bindgen module, and I have also gotten some warnings due to improper ctypes in the past. This PR silences both.