### PR TITLE
Updated dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ispc"
-version = "1.0.9"
+version = "1.0.10"
 authors = ["Will Usher <will@willusher.io>"]
 homepage = "https://github.com/Twinklebear/ispc-rs"
 documentation = "https://docs.rs/ispc/"
@@ -26,6 +26,6 @@ exclude = [
 ]
 
 [dependencies]
-ispc_compile = { path = "./compile/", version = "1.0.9" }
-ispc_rt = { path = "./runtime/", version = "1.0.4" }
+ispc_compile = { path = "./compile/", version = "1.0.10" }
+ispc_rt = { path = "./runtime/", version = "1.0.5" }
 

--- a/compile/Cargo.toml
+++ b/compile/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ispc_compile"
-version = "1.0.9"
+version = "1.0.10"
 authors = ["Will Usher <will@willusher.io>"]
 homepage = "https://github.com/Twinklebear/ispc-rs"
 documentation = "https://docs.rs/ispc_compile/"
@@ -27,9 +27,9 @@ exclude = [
 ]
 
 [dependencies]
-bindgen = "0.53"
+bindgen = "0.59.2"
 gcc = "0.3.55"
-libc = "0.2"
-regex = "1.3"
-semver = "0.9.0"
+libc = "0.2.117"
+regex = "1.5.4"
+semver = "1.0.5"
 

--- a/compile/src/lib.rs
+++ b/compile/src/lib.rs
@@ -37,7 +37,7 @@ use std::env;
 use std::collections::BTreeSet;
 
 use regex::Regex;
-use semver::Version;
+use semver::{Version, Prerelease, BuildMetadata};
 
 pub use opt::{MathLib, Addressing, Architecture, CPU, OptimizationOpt, TargetISA};
 
@@ -259,7 +259,7 @@ impl Config {
     /// Emit instrumentation code for ISPC to gather performance data such
     /// as vector utilization.
     pub fn instrument(&mut self) -> &mut Config {
-        let min_ver = Version { major: 1, minor: 9, patch: 1, pre: vec![], build: vec![] };
+        let min_ver = Version { major: 1, minor: 9, patch: 1, pre: Prerelease::EMPTY, build: BuildMetadata::EMPTY };
         if self.ispc_version < min_ver {
             exit_failure!("Error: instrumentation is not supported on ISPC versions \
                           older than 1.9.1 as it generates a non-C compatible header");
@@ -412,7 +412,7 @@ impl Config {
     fn generate_bindgen_header(&mut self, lib: &str) {
         self.bindgen_header = self.get_build_dir().join(format!("_{}_ispc_bindgen_header.h", lib));
         let mut include_file = File::create(&self.bindgen_header).unwrap();
-       
+
         writeln!(include_file, "#include <stdint.h>").unwrap();
         writeln!(include_file, "#include <stdbool.h>").unwrap();
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ispc_rt"
-version = "1.0.4"
+version = "1.0.5"
 authors = ["Will Usher <will@willusher.io>"]
 homepage = "https://github.com/Twinklebear/ispc-rs"
 documentation = "https://docs.rs/ispc_rt/"
@@ -24,7 +24,7 @@ exclude = [
 ]
 
 [dependencies]
-libc = "0.2"
+libc = "0.2.117"
 aligned_alloc = "0.1.3"
-num_cpus = "1.11"
+num_cpus = "1.13.1"
 


### PR DESCRIPTION
Updated dependencies - especially bindgen, which itself depends on clang-sys and can cause versioning problems when other crates in a project also depend on pre-built clang.