### PR TITLE
Fix Cargo change detection in the runtime

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -73,13 +73,13 @@ impl PackagedModule {
     }
     /// Link with a previously built ISPC library packaged with the crate
     pub fn link(&self) {
-        let libfile = self.lib.clone() + &env::var("HOST").unwrap();
-        let bindgen_file = self.lib.clone() + ".rs";
-        println!("cargo:rerun-if-changed={}", libfile);
-        println!("cargo:rerun-if-changed={}", bindgen_file);
-        println!("cargo:rustc-link-lib=static={}", libfile);
-
         let path = self.get_lib_path();
+        let libfile = self.lib.clone() + &env::var("TARGET").unwrap();
+        let bindgen_file = self.lib.clone() + ".rs";
+        
+        println!("cargo:rustc-link-lib=static={}", libfile);
+        println!("cargo:rerun-if-changed={}", path.join(get_lib_filename(&libfile)).display());
+        println!("cargo:rerun-if-changed={}", path.join(bindgen_file).display());
         println!("cargo:rustc-link-search=native={}", path.display());
         println!("cargo:rustc-env=ISPC_OUT_DIR={}", path.display());
     }
@@ -94,6 +94,14 @@ impl PackagedModule {
         } else {
             p
         }
+    }
+}
+
+fn get_lib_filename(libfile: &str) -> String {
+    if libfile.contains("windows") {
+        format!("{}.lib", libfile)
+    } else {
+        format!("lib{}.a", libfile)
     }
 }
 


### PR DESCRIPTION
* Fix change detection for by setting the full path of rs and lib file, otherwise the build script gets evaluated at each run, the problem arises when the crate using the runtime is down the dependency graph causing all it's children to be compiled.
* Using target instead of host, to build for cross compilation scenarios (not tested)