### PR TITLE
Replace usage of aligned_alloc with std::alloc

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -25,6 +25,6 @@ exclude = [
 
 [dependencies]
 libc = "0.2.117"
-aligned_alloc = "0.1.3"
+# aligned_alloc = "0.1.3" Remove because deprecated in favor of std::alloc
 num_cpus = "1.13.1"
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -11,7 +11,6 @@
 #![allow(dead_code)]
 
 extern crate libc;
-extern crate aligned_alloc;
 extern crate num_cpus;
 
 pub mod task;


### PR DESCRIPTION
The aligned_alloc crate was declared deprecated by its creator 17 months ago in favor of std::alloc. While it was working correctly, it could cause issues with crate versions banned by cargo deny, since the dependencies used by it were old.

These changed replace the usage of aligned_alloc with std::alloc from the standard library. The new code was tested within a private repo, with no noticeable differences in the output.