### PR TITLE
examples/custom_tasksys: Replace yanked `aligned_alloc` with `std::alloc`

### DIFF
--- a/examples/custom_tasksys/Cargo.toml
+++ b/examples/custom_tasksys/Cargo.toml
@@ -6,7 +6,6 @@ build = "build.rs"
 
 [dependencies]
 libc = "0.2"
-aligned_alloc = "0.1.3"
 ispc = { path = "../../" }
 
 [build-dependencies]


### PR DESCRIPTION
This crate has been deprecated and yanked in favour of the stabilised `std::alloc` APIs.  Without this change it cannot be built.
