### PR TITLE
examples: Update dependencies, specifically `image` to get rid of CVE-2020-35916

### DIFF
--- a/examples/aobench/Cargo.toml
+++ b/examples/aobench/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Will Usher <willusher.life@gmail.com>"]
 build = "build.rs"
 
 [dependencies]
-image = "0.22"
-rand = "0.7"
+image = "0.24"
+rand = "0.8"
 ispc = { path = "../../" }
 
 [build-dependencies]

--- a/examples/aobench/src/main.rs
+++ b/examples/aobench/src/main.rs
@@ -42,7 +42,7 @@ fn main() {
         &img[..],
         width as u32,
         height as u32,
-        image::Gray(8),
+        image::ColorType::L8,
     ) {
         Ok(_) => println!("AO Bench image saved to ao.png"),
         Err(e) => panic!("Error saving AO Bench image: {}", e),

--- a/examples/ddvol/Cargo.toml
+++ b/examples/ddvol/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Will Usher <willusher.life@gmail.com>"]
 build = "build.rs"
 
 [dependencies]
-image = "0.22"
-rand = "0.5"
-num = "0.2"
+image = "0.24"
+rand = "0.8"
+num = "0.4"
 serde_json = "1.0.41"
 serde_derive = "1.0.102"
 serde = "1.0.102"

--- a/examples/ddvol/scenes/tacc-turbulence.json
+++ b/examples/ddvol/scenes/tacc-turbulence.json
@@ -1,6 +1,6 @@
 {
 	"volume": {
-		"note":"You can get csafe from http://www.ospray.org/ examples",
+		"note": "You can get the volume from http://www.ospray.org/ examples",
 		"file": "tacc-turbulence-256-volume/tacc-turbulence-256-volume.raw",
 		"data_type": "f32",
 		"dimensions": [256, 256, 256]

--- a/examples/ddvol/src/main.rs
+++ b/examples/ddvol/src/main.rs
@@ -93,7 +93,7 @@ fn main() {
         &srgb_img[..],
         scene.width as u32,
         scene.height as u32,
-        image::RGB(8),
+        image::ColorType::Rgb8,
     ) {
         Ok(_) => println!("Rendered image saved to {}", out_file),
         Err(e) => panic!("Error saving image: {}", e),

--- a/examples/ddvol/src/raw.rs
+++ b/examples/ddvol/src/raw.rs
@@ -18,7 +18,7 @@ use vol::Volume;
 pub fn import<T: NumCast>(path: &Path, dims: Vec3i) -> Volume {
     let mut f = match File::open(&path) {
         Ok(f) => BufReader::new(f),
-        Err(e) => panic!("Error opening volume {}", e),
+        Err(e) => panic!("Error opening volume `{:?}`: {}", path, e),
     };
     let mut data: Vec<_> = iter::repeat(0u8)
         .take((dims.x * dims.y * dims.z) as usize * mem::size_of::<T>())

--- a/examples/mandelbrot/Cargo.toml
+++ b/examples/mandelbrot/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Will Usher <willusher.life@gmail.com>"]
 build = "build.rs"
 
 [dependencies]
-image = "0.22"
+image = "0.24"
 ispc = { path = "../../" }
 
 [build-dependencies]

--- a/examples/mandelbrot/src/main.rs
+++ b/examples/mandelbrot/src/main.rs
@@ -32,7 +32,7 @@ fn main() {
         &img[..],
         width as u32,
         height as u32,
-        image::Gray(8),
+        image::ColorType::L8,
     ) {
         Ok(_) => println!("Mandelbrot image saved to mandelbrot.png"),
         Err(e) => panic!("Error saving Mandelbrot image: {}", e),

--- a/examples/perlin/Cargo.toml
+++ b/examples/perlin/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Will Usher <willusher.life@gmail.com>"]
 build = "build.rs"
 
 [dependencies]
-image = "0.22"
+image = "0.24"
 ispc = { path = "../../" }
 
 [build-dependencies]

--- a/examples/perlin/src/main.rs
+++ b/examples/perlin/src/main.rs
@@ -37,7 +37,7 @@ fn main() {
         &img[..],
         img_width as u32,
         img_height as u32,
-        image::Gray(8),
+        image::ColorType::L8,
     ) {
         Ok(_) => println!("Perlin noise saved to perlin.png"),
         Err(e) => panic!("Error saving Perlin noise image: {}", e),

--- a/examples/rt/Cargo.toml
+++ b/examples/rt/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Will Usher <willusher.life@gmail.com>"]
 build = "build.rs"
 
 [dependencies]
-image = "0.22"
-rand = "0.5"
-num = "0.2"
+image = "0.24"
+rand = "0.8"
+num = "0.4"
 serde_json = "1.0.41"
 serde_derive = "1.0.102"
 serde = "1.0.102"

--- a/examples/rt/src/main.rs
+++ b/examples/rt/src/main.rs
@@ -91,7 +91,7 @@ fn main() {
         &srgb_img_buf[..],
         scene.width as u32,
         scene.height as u32,
-        image::RGB(8),
+        image::ColorType::Rgb8,
     ) {
         Ok(_) => println!("Rendered image saved to {}", out_file),
         Err(e) => panic!("Error saving image: {}", e),


### PR DESCRIPTION
I recently enabled dependabot security alerts (not to be confused with regular dependabot update PRs) and it triggered on my fork of `ispc-rs`: while only the examples that aren't released, it's good to give them some TLC.
