### PR TITLE
Add missing `edition = "2021"` to `compile` and `runtime` crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ ispc_compile = { path = "./compile/", version = "1.1.0" }
 ispc_rt = { path = "./runtime/", version = "1.1.0" }
 
 [workspace]
-edition = "2021"
 resolver = "2"
 members = [
 	"compile",

--- a/compile/Cargo.toml
+++ b/compile/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ispc_compile"
 version = "1.1.0"
+edition = "2021"
 authors = ["Will Usher <will@willusher.io>"]
 homepage = "https://github.com/Twinklebear/ispc-rs"
 documentation = "https://docs.rs/ispc_compile/"
@@ -32,4 +33,3 @@ gcc = "0.3.55"
 libc = "0.2.117"
 regex = "1.5.4"
 semver = "1.0.5"
-

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ispc_rt"
 version = "1.1.0"
+edition = "2021"
 authors = ["Will Usher <will@willusher.io>"]
 homepage = "https://github.com/Twinklebear/ispc-rs"
 documentation = "https://docs.rs/ispc_rt/"
@@ -26,4 +27,3 @@ exclude = [
 [dependencies]
 libc = "0.2.117"
 num_cpus = "1.13.1"
-


### PR DESCRIPTION
Commit ad85f13 ("Seems like edition in workspace isn't applied? Update all to 2021") found that `workspace.edition` isn't a valid key and added it to most crates' individual `[package]` table, but didn't remove the key from `[workspace]` nor added it to the `compile` and `runtime` crates:

```
warning: ispc-rs/Cargo.toml: unused manifest key: workspace.edition
```

Note that `[workspace.package] edition = "2021"` exists since Rust 1.64, but still requires `[package] edition.workspace = true` to be repeated in every individual `Cargo.toml` for it to be inherited: https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table
