### PR TITLE
compile: Upgrade to `bindgen 0.61` and use `Builder` with `Clone`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ ispc_compile = { path = "./compile/", version = "1.1.0" }
 ispc_rt = { path = "./runtime/", version = "1.1.0" }
 
 [workspace]
-edition = "2021"
 resolver = "2"
 members = [
 	"compile",

--- a/compile/Cargo.toml
+++ b/compile/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ispc_compile"
 version = "1.1.0"
+edition = "2021"
 authors = ["Will Usher <will@willusher.io>"]
 homepage = "https://github.com/Twinklebear/ispc-rs"
 documentation = "https://docs.rs/ispc_compile/"
@@ -32,4 +33,3 @@ gcc = "0.3.55"
 libc = "0.2.117"
 regex = "1.5.4"
 semver = "1.0.5"
-

--- a/compile/Cargo.toml
+++ b/compile/Cargo.toml
@@ -28,7 +28,7 @@ exclude = [
 ]
 
 [dependencies]
-bindgen = "0.59.2"
+bindgen = "0.61.0"
 gcc = "0.3.55"
 libc = "0.2.117"
 regex = "1.5.4"

--- a/examples/simple/build.rs
+++ b/examples/simple/build.rs
@@ -19,9 +19,7 @@ fn link_ispc() {
     #[cfg(target_arch = "aarch64")]
     let target_isas = vec![TargetISA::Neoni32x4];
 
-    let bindgen_opts = ispc_compile::BindgenOptions {
-        allowlist_functions: vec![std::borrow::Cow::Borrowed(&"add_lists")],
-    };
+    let bindgen_builder = ispc_compile::bindgen::builder().allowlist_function("add_lists");
 
     // For a portable program we can explicitly compile for each target ISA
     // we want. Then ISPC will pick the correct ISA at runtime to call
@@ -29,7 +27,7 @@ fn link_ispc() {
     ispc_compile::Config::new()
         .file("src/simple.ispc")
         .target_isas(target_isas)
-        .bindgen_options(bindgen_opts)
+        .bindgen_builder(bindgen_builder)
         .out_dir("src/")
         .compile("simple");
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ispc_rt"
 version = "1.1.0"
+edition = "2021"
 authors = ["Will Usher <will@willusher.io>"]
 homepage = "https://github.com/Twinklebear/ispc-rs"
 documentation = "https://docs.rs/ispc_rt/"
@@ -26,4 +27,3 @@ exclude = [
 [dependencies]
 libc = "0.2.117"
 num_cpus = "1.13.1"
-


### PR DESCRIPTION
Depends on #21 for `pub use bindgen;` (perhaps all `extern crate` should be replaced since moving to edition 2021?)

As announced earlier in #20 when introducing `BindgenOptions`, upstream `bindgen` didn't yet allow cloning nor copying their `Builder` struct, limiting it to generate a single binding per `Builder` object.  This doesn't fit with ispc-rs's `Config` struct which explicitly allows multiple libraries to be compiled using (partially) the same base configuration (barring any side-effects from `fn compile(&mut self, lib)` updating various fields depending on `lib`).

This issue has since been addressed upstream, and now allows us to move and clone the `bindgen::Builder` around instead of implementing a very limited subset of config fields and manually reconstructing the builder every time.
