### PR TITLE
Run clippy in the CI with warnings disallowed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
             - run: curl -L https://github.com/ispc/ispc/releases/download/v${{ env.ISPC_VERSION }}/ispc-v${{ env.ISPC_VERSION }}-linux.tar.gz | tar xzv ispc-v${{ env.ISPC_VERSION }}-linux/bin/ispc
             - run: realpath "ispc-v${{ env.ISPC_VERSION }}-linux/bin/" >> $GITHUB_PATH
             - run: cargo build --all --all-targets --features ispc
+            - run: cargo clippy --all --all-targets --features ispc -- -D warnings
             - run: cargo test --all
             - run: cargo doc --all --no-deps --document-private-items --all-features
               env:
@@ -29,6 +30,7 @@ jobs:
                   toolchain: stable
             - run: brew install ispc
             - run: cargo build --all --all-targets --features ispc
+            - run: cargo clippy --all --all-targets --features ispc -- -D warnings
             - run: cargo test --all
     build_windows:
         runs-on: windows-latest
@@ -42,4 +44,5 @@ jobs:
                   unzip ispc-v${{ env.ISPC_VERSION }}-windows.zip ispc-v${{ env.ISPC_VERSION }}-windows/bin/ispc.exe
                   Resolve-Path "ispc-v${{ env.ISPC_VERSION }}-windows/bin" | Add-Content -Path $env:GITHUB_PATH
             - run: cargo build --all --all-targets --features ispc
+            - run: cargo clippy --all --all-targets --features ispc -- -D warnings
             - run: cargo test --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ ispc_compile = { path = "./compile/", version = "1.1.0" }
 ispc_rt = { path = "./runtime/", version = "1.1.0" }
 
 [workspace]
-edition = "2021"
 resolver = "2"
 members = [
 	"compile",

--- a/compile/Cargo.toml
+++ b/compile/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ispc_compile"
 version = "1.1.0"
+edition = "2021"
 authors = ["Will Usher <will@willusher.io>"]
 homepage = "https://github.com/Twinklebear/ispc-rs"
 documentation = "https://docs.rs/ispc_compile/"
@@ -32,4 +33,3 @@ gcc = "0.3.55"
 libc = "0.2.117"
 regex = "1.5.4"
 semver = "1.0.5"
-

--- a/compile/Cargo.toml
+++ b/compile/Cargo.toml
@@ -28,7 +28,7 @@ exclude = [
 ]
 
 [dependencies]
-bindgen = "0.59.2"
+bindgen = "0.61.0"
 gcc = "0.3.55"
 libc = "0.2.117"
 regex = "1.5.4"

--- a/compile/src/lib.rs
+++ b/compile/src/lib.rs
@@ -60,7 +60,7 @@ pub use crate::opt::{
 /// ```
 pub fn compile_library(lib: &str, files: &[&str]) {
     let mut cfg = Config::new();
-    for f in &files[..] {
+    for f in files {
         cfg.file(*f);
     }
     cfg.compile(lib)

--- a/compile/src/opt.rs
+++ b/compile/src/opt.rs
@@ -155,7 +155,7 @@ impl ToString for OptimizationOpt {
 
 /// Target instruction sets and vector widths available to specialize for. The
 /// default if none is set will be the host CPU's ISA and vector width.
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum TargetISA {
     Host,
     SSE2i32x4,

--- a/examples/ddvol/src/fb.rs
+++ b/examples/ddvol/src/fb.rs
@@ -12,8 +12,8 @@ pub struct Framebuffer {
 impl Framebuffer {
     pub fn new(width: usize, height: usize) -> Framebuffer {
         Framebuffer {
-            width: width,
-            height: height,
+            width,
+            height,
             data: vec![0.0; width * height * 4],
         }
     }

--- a/examples/ddvol/src/main.rs
+++ b/examples/ddvol/src/main.rs
@@ -34,7 +34,7 @@ pub fn empty_handle() -> ISPCHandle {
     ptr::null::<*mut ::std::os::raw::c_void>() as ISPCHandle
 }
 
-const USAGE: &'static str = "
+const USAGE: &str = "
 Usage:
   ddvol <scene> [options]
   ddvol (-h | --help)
@@ -84,7 +84,7 @@ fn main() {
         );
     }
     let out_file = match args.flag_o {
-        Some(s) => s.clone(),
+        Some(s) => s,
         None => String::from("ddvol.png"),
     };
     let srgb_img = framebuffer.srgb8();

--- a/examples/ddvol/src/scene.rs
+++ b/examples/ddvol/src/scene.rs
@@ -85,12 +85,12 @@ impl Scene {
             .expect("image height must be an int") as usize;
         let mut volume = Scene::load_volume(
             data.get("volume").expect("A volume must be specified"),
-            &base_path,
+            base_path,
         );
         let tfn = Scene::load_transfer_function(
             data.get("transfer_function")
                 .expect("A transfer function must be specified"),
-            &base_path,
+            base_path,
         );
         volume.set_transfer_function(tfn);
 
@@ -103,8 +103,8 @@ impl Scene {
         Scene {
             width: img_width,
             height: img_height,
-            camera: camera,
-            volume: volume,
+            camera,
+            volume,
             params: render_params,
         }
     }
@@ -273,8 +273,8 @@ impl Scene {
             .as_i64()
             .expect("n_samples must be an int") as i32;
         RenderParams {
-            background: background,
-            n_samples: n_samples,
+            background,
+            n_samples,
         }
     }
     fn load_vec3i(e: &Value) -> Option<Vec3i> {

--- a/examples/ddvol/src/vec3.rs
+++ b/examples/ddvol/src/vec3.rs
@@ -9,16 +9,16 @@ pub type Vec3i = crate::ddvol::Vec3i;
 
 impl Vec3f {
     pub fn broadcast(x: f32) -> Vec3f {
-        Vec3f { x: x, y: x, z: x }
+        Vec3f { x, y: x, z: x }
     }
     pub fn new(x: f32, y: f32, z: f32) -> Vec3f {
-        Vec3f { x: x, y: y, z: z }
+        Vec3f { x, y, z }
     }
     pub fn dot(&self, b: &Vec3f) -> f32 {
         self.x * b.x + self.y * b.y + self.z * b.z
     }
     pub fn length(&self) -> f32 {
-        f32::sqrt(self.dot(&self))
+        f32::sqrt(self.dot(self))
     }
     pub fn normalized(&self) -> Vec3f {
         let inv_len = 1.0 / self.length();
@@ -131,10 +131,10 @@ impl Div<f32> for Vec3f {
 
 impl Vec3i {
     pub fn broadcast(x: i32) -> Vec3i {
-        Vec3i { x: x, y: x, z: x }
+        Vec3i { x, y: x, z: x }
     }
     pub fn new(x: i32, y: i32, z: i32) -> Vec3i {
-        Vec3i { x: x, y: y, z: z }
+        Vec3i { x, y, z }
     }
 }
 

--- a/examples/ddvol/src/vol.rs
+++ b/examples/ddvol/src/vol.rs
@@ -25,7 +25,7 @@ impl Volume {
         }
         Volume {
             ispc_handle: vol,
-            tfn: tfn,
+            tfn,
         }
     }
     /// Set the transfer function used by the volume, overriding the default cool/warm.

--- a/examples/rt/src/camera.rs
+++ b/examples/rt/src/camera.rs
@@ -25,12 +25,12 @@ impl Camera {
         let screen_dv = dy * dim_y;
         let dir_top_left = dz - 0.5 * screen_du - 0.5 * screen_dv;
         Camera {
-            pos: pos,
+            pos,
             dir: dir.normalized(),
             up: up.normalized(),
-            dir_top_left: dir_top_left,
-            screen_du: screen_du,
-            screen_dv: screen_dv,
+            dir_top_left,
+            screen_du,
+            screen_dv,
             width: width as i32,
             height: height as i32,
         }

--- a/examples/rt/src/geom.rs
+++ b/examples/rt/src/geom.rs
@@ -39,8 +39,8 @@ impl Sphere {
             );
         }
         Sphere {
-            center: center,
-            radius: radius,
+            center,
+            radius,
             material: mat,
             ispc_geom: geom,
         }
@@ -82,7 +82,7 @@ impl Plane {
             );
         }
         Plane {
-            center: center,
+            center,
             normal: n,
             material: mat,
             ispc_geom: geom,

--- a/examples/rt/src/lights.rs
+++ b/examples/rt/src/lights.rs
@@ -25,8 +25,8 @@ impl PointLight {
             );
         }
         PointLight {
-            position: position,
-            emission: emission,
+            position,
+            emission,
             ispc_equiv: light,
         }
     }

--- a/examples/rt/src/main.rs
+++ b/examples/rt/src/main.rs
@@ -28,7 +28,7 @@ mod vec3f;
 
 ispc_module!(rt);
 
-const USAGE: &'static str = "
+const USAGE: &str = "
 Usage:
   rt <scene> [options]
   rt (-h | --help)
@@ -83,7 +83,7 @@ fn main() {
         );
     }
     let out_file = match args.flag_o {
-        Some(s) => s.clone(),
+        Some(s) => s,
         None => String::from("rt.png"),
     };
     match image::save_buffer(

--- a/examples/rt/src/material.rs
+++ b/examples/rt/src/material.rs
@@ -21,7 +21,7 @@ impl Lambertian {
             rt::make_lambertian(&mut mat as *mut *const Material, &albedo as *const Vec3f);
         }
         Lambertian {
-            albedo: albedo,
+            albedo,
             ispc_equiv: mat,
         }
     }

--- a/examples/rt/src/scene.rs
+++ b/examples/rt/src/scene.rs
@@ -105,10 +105,10 @@ impl Scene {
         Scene {
             width: img_width,
             height: img_height,
-            n_samples: n_samples,
-            camera: camera,
+            n_samples,
+            camera,
             geometry: geom,
-            light: light,
+            light,
         }
     }
     fn load_camera(e: &Value, width: usize, height: usize) -> Camera {

--- a/examples/rt/src/vec3f.rs
+++ b/examples/rt/src/vec3f.rs
@@ -6,16 +6,16 @@ pub type Vec3f = crate::rt::Vec3f;
 
 impl Vec3f {
     pub fn broadcast(x: f32) -> Vec3f {
-        Vec3f { x: x, y: x, z: x }
+        Vec3f { x, y: x, z: x }
     }
     pub fn new(x: f32, y: f32, z: f32) -> Vec3f {
-        Vec3f { x: x, y: y, z: z }
+        Vec3f { x, y, z }
     }
     pub fn dot(&self, b: &Vec3f) -> f32 {
         self.x * b.x + self.y * b.y + self.z * b.z
     }
     pub fn length(&self) -> f32 {
-        f32::sqrt(self.dot(&self))
+        f32::sqrt(self.dot(self))
     }
     pub fn normalized(&self) -> Vec3f {
         let inv_len = 1.0 / self.length();

--- a/examples/simple/build.rs
+++ b/examples/simple/build.rs
@@ -19,9 +19,7 @@ fn link_ispc() {
     #[cfg(target_arch = "aarch64")]
     let target_isas = vec![TargetISA::Neoni32x4];
 
-    let bindgen_opts = ispc_compile::BindgenOptions {
-        allowlist_functions: vec![std::borrow::Cow::Borrowed(&"add_lists")],
-    };
+    let bindgen_builder = ispc_compile::bindgen::builder().allowlist_function("add_lists");
 
     // For a portable program we can explicitly compile for each target ISA
     // we want. Then ISPC will pick the correct ISA at runtime to call
@@ -29,7 +27,7 @@ fn link_ispc() {
     ispc_compile::Config::new()
         .file("src/simple.ispc")
         .target_isas(target_isas)
-        .bindgen_options(bindgen_opts)
+        .bindgen_builder(bindgen_builder)
         .out_dir("src/")
         .compile("simple");
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ispc_rt"
 version = "1.1.0"
+edition = "2021"
 authors = ["Will Usher <will@willusher.io>"]
 homepage = "https://github.com/Twinklebear/ispc-rs"
 documentation = "https://docs.rs/ispc_rt/"
@@ -26,4 +27,3 @@ exclude = [
 [dependencies]
 libc = "0.2.117"
 num_cpus = "1.13.1"
-

--- a/runtime/src/task.rs
+++ b/runtime/src/task.rs
@@ -112,7 +112,7 @@ impl Context {
         let tasks = self.tasks.read().unwrap();
         for group in tasks.iter() {
             if group.has_tasks() {
-                return Some(Arc::clone(&group));
+                return Some(Arc::clone(group));
             }
         }
         None


### PR DESCRIPTION
Depends on #21, and #22 as the latest `bindgen` fixes clippy lints in generated code

As discussed previously it'd be nice to keep `ispc-rs` "free" of simple "code smells" commonly pointed out by `clippy`.  This is easy to guard by disallowing any clippy warnings from trickling into the codebase through PRs via an extra CI check.

Downside is that Rust upgrades every 6 weeks and usually enables new or improves existing lints, resulting in unrelated CI errors caused by existing code being punted on unsuspecting contributors in newly opened PRs.  But these are typically easy to resolve in a separate PR, or to be caught early when (also) running the CI job on a schedule.

