### PR TITLE
ci: Test binaries on latest ISPC 1.20 release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
         - cron: "0 0 * * 1"
 env:
     CARGO_TERM_COLOR: always
-    ISPC_VERSION: 1.18.0
+    ISPC_VERSION: 1.20.0
 jobs:
     build_linux:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Make sure we're compatible with the latest compiler release that just dropped: https://github.com/ispc/ispc/releases/tag/v1.20.0