### PR TITLE
compile: Replace ancient `gcc` crate with `cc`

### DIFF
--- a/compile/Cargo.toml
+++ b/compile/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 
 [dependencies]
 bindgen = "0.61.0"
-gcc = "0.3.55"
+cc = "1"
 libc = "0.2.137"
 regex = "1.7.0"
 semver = "1.0.14"

--- a/compile/src/lib.rs
+++ b/compile/src/lib.rs
@@ -20,11 +20,6 @@
 //! `libclang.lib` to `clang.lib` and place it in your path.
 //!
 
-extern crate gcc;
-extern crate libc;
-extern crate regex;
-extern crate semver;
-
 pub mod opt;
 
 pub use bindgen;
@@ -433,7 +428,7 @@ impl Config {
     #[cfg(windows)]
     fn assemble(&self, lib: &str, objects: &[PathBuf]) -> ExitStatus {
         let target = self.get_target();
-        let mut lib_cmd = gcc::windows_registry::find_tool(&target, "lib.exe")
+        let mut lib_cmd = cc::windows_registry::find_tool(&target, "lib.exe")
             .expect("Failed to find lib.exe for MSVC toolchain, aborting")
             .to_command();
         lib_cmd


### PR DESCRIPTION
The `gcc` crate hasn't been updated for 5 years and clearly states that is deprecated after a rename to `cc`.

More importantly we're cross-compiling some Windows ISPC code to aarch64 and while GitHub's actions runners definitely have [all the cross-compiling packages installed] the old `gcc` crate was complaining that it could not find `lib.exe` for the desired target.

Note that this strangely happened to work fine on a developer machine, but it is unclear why.

[all the cross-compiling packages installed]: https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md#workloads-components-and-extensions
