### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: "/.github/workflows/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Enable dependabot on a weekly schedule to get PRs (notifications) for crate dependency upgrades, as well as GitHub Actions step updates.

(I intended to submit this _before_ the `checkout@v4` bump, to show that it can point out and automate these things)
