### PR TITLE
MacOS: Install `ispc` by downloading **versioned** release from GitHub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,8 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
-            - run: curl -L https://github.com/ispc/ispc/releases/download/v${{ env.ISPC_VERSION }}/ispc-v${{ env.ISPC_VERSION }}-linux.tar.gz | tar xzv ispc-v${{ env.ISPC_VERSION }}-linux/bin/ispc
-            - run: realpath "ispc-v${{ env.ISPC_VERSION }}-linux/bin/" >> $GITHUB_PATH
+            - run: curl -L https://github.com/ispc/ispc/releases/download/v$ISPC_VERSION/ispc-v$ISPC_VERSION-linux.tar.gz | tar xzv ispc-v$ISPC_VERSION-linux/bin/ispc
+            - run: realpath "ispc-v$ISPC_VERSION-linux/bin/" >> $GITHUB_PATH
             - run: cargo build --all --all-targets --features ispc
             - run: cargo clippy --all --all-targets --features ispc -- -D warnings
             - run: cargo test --all
@@ -26,8 +26,10 @@ jobs:
         runs-on: macos-latest
         steps:
             - uses: actions/checkout@v4
-            - run: brew update
-            - run: brew install ispc
+            - name: Prepare Environment
+              run: |
+                curl -L https://github.com/ispc/ispc/releases/download/v$ISPC_VERSION/ispc-v$ISPC_VERSION-macOS.x86_64.tar.gz | tar xzv ispc-v$ISPC_VERSION-macOS.x86_64/bin/ispc
+                echo "$PWD/ispc-v$ISPC_VERSION-macOS.x86_64/bin/" >> $GITHUB_PATH
             - run: cargo build --all --all-targets --features ispc
             - run: cargo clippy --all --all-targets --features ispc -- -D warnings
             - run: cargo test --all
@@ -36,9 +38,9 @@ jobs:
         steps:
             - uses: actions/checkout@v4
             - run: |
-                  curl -LO https://github.com/ispc/ispc/releases/download/v${{ env.ISPC_VERSION }}/ispc-v${{ env.ISPC_VERSION }}-windows.zip
-                  unzip ispc-v${{ env.ISPC_VERSION }}-windows.zip ispc-v${{ env.ISPC_VERSION }}-windows/bin/ispc.exe
-                  Resolve-Path "ispc-v${{ env.ISPC_VERSION }}-windows/bin" | Add-Content -Path $env:GITHUB_PATH
+                  curl -LO https://github.com/ispc/ispc/releases/download/v$env:ISPC_VERSION/ispc-v$env:ISPC_VERSION-windows.zip
+                  unzip ispc-v$env:ISPC_VERSION-windows.zip ispc-v$env:ISPC_VERSION-windows/bin/ispc.exe
+                  Resolve-Path "ispc-v$env:ISPC_VERSION-windows/bin" | Add-Content -Path $env:GITHUB_PATH
             - run: cargo build --all --all-targets --features ispc
             - run: cargo clippy --all --all-targets --features ispc -- -D warnings
             - run: cargo test --all


### PR DESCRIPTION
`brew` keeps horribly breaking, and a `brew install ispc` after a `brew upgrade` takes an insulting 13 minutes to also update all kinds of unrelated "formulae" that are irrelevant to the request to simply upgrade `ispc` (and direct dependencies).  And it doesn't even allow us to pin the version to match the Linux and Windows jobs.

This is simply solved by mimicking the Linux/Windows install process, by downloading the latest versioned `ispc` binary from GitHub, extracting it, and passing the path to `GITHUB_PATH`.

Also clean up some inconsistencies in env var resolving, to all resolve them inside the shell script (via `$var` on UNIX and `$env:var` on Windows) as `${{ env.var }}` doesn't work in every context (i.e. to get to `GITHUB_PATH`).