### PR TITLE
Remove broken `#[allow]` on `include!()` from #34

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -45,7 +45,6 @@ pub use crate::task::ISPCTaskFn;
 #[macro_export]
 macro_rules! ispc_module {
     ($lib:ident) => {
-        #[allow(clippy::all)]
         include!(concat!(env!("ISPC_OUT_DIR"), "/", stringify!($lib), ".rs"));
     };
 }


### PR DESCRIPTION
Having a `#[allow]` on top of `include!()` only applies to the first statement in the included file, hence has very little effect. Furthermore `bindgen 0.70.1` now emits the necessary `#[allow]`s already to appease `clippy`, making this redundant even if it was correctly applying to the surrounding module with `#![allow]`.