### PR TITLE
Fix all new clippy lints since Rust 1.88

### DIFF
--- a/compile/src/opt.rs
+++ b/compile/src/opt.rs
@@ -226,7 +226,7 @@ impl std::fmt::Display for OptimizationOpt {
             OptimizationOpt::ForceAlignedMemory => "force-aligned-memory",
             OptimizationOpt::ResetFTZDaz => "reset-ftz-daz",
         };
-        write!(f, "--opt={}", option_str)
+        write!(f, "--opt={option_str}")
     }
 }
 


### PR DESCRIPTION
This makes the CI in both PRs/pushes and the nightly runs happy again.

While at it, I've replaced some `to_string()` calls with a format string which should be ever so slightly more efficient by saving on an allocation.
